### PR TITLE
Fix cull completely doesn't animate invisible object.

### DIFF
--- a/Assets/SimpleAnimationComponent/Tests/PlaymodeTests/ComparativeTests/BaseConditionsTests.cs
+++ b/Assets/SimpleAnimationComponent/Tests/PlaymodeTests/ComparativeTests/BaseConditionsTests.cs
@@ -58,7 +58,7 @@ public class BaseConditionsTests
 
         animation.cullingMode = AnimatorCullingMode.CullCompletely;
         animation.AddClip(clipInstance, "test");
-        animation.gameObject.GetComponent<MeshRenderer>().enabled = true;
+        animation.gameObject.GetComponent<MeshRenderer>().enabled = false;
         animation.Play("test");
 
         yield return null;


### PR DESCRIPTION
Make the object invisible by disabling the `MeshRenderer`.