### PR TITLE
Fix continuous crossfade

### DIFF
--- a/Assets/SimpleAnimationComponent/SimpleAnimationPlayable.cs
+++ b/Assets/SimpleAnimationComponent/SimpleAnimationPlayable.cs
@@ -347,7 +347,7 @@ public partial class SimpleAnimationPlayable : PlayableBehaviour
         float travel = Mathf.Abs(state.weight - targetWeight);
         float newSpeed = time != 0f ? travel / time : Mathf.Infinity;
         
-        // If we're fading to the same target as before but faster, assume CrossFade was called multiple times and ignore new speed
+        // If we're fading to the same target as before but slower, assume CrossFade was called multiple times and ignore new speed
         if (state.fading && Mathf.Approximately(state.targetWeight, targetWeight) && newSpeed < state.fadeSpeed)
             return;
 

--- a/Assets/SimpleAnimationComponent/SimpleAnimationPlayable.cs
+++ b/Assets/SimpleAnimationComponent/SimpleAnimationPlayable.cs
@@ -344,11 +344,15 @@ public partial class SimpleAnimationPlayable : PlayableBehaviour
 
     private void SetupLerp(StateInfo state, float targetWeight, float time)
     {
-        float travel = Mathf.Abs(state.targetWeight - targetWeight);
+        float travel = Mathf.Abs(state.weight - targetWeight);
+        float newSpeed = time != 0f ? travel / time : Mathf.Infinity;
+        
+        // If we're fading to the same target as before but faster, assume CrossFade was called multiple times and ignore new speed
+        if (state.fading && Mathf.Approximately(state.targetWeight, targetWeight) && newSpeed < state.fadeSpeed)
+            return;
 
         state.fading = travel > 0f;
-
-        state.fadeSpeed = time != 0f ? travel / time : Mathf.Infinity;
+        state.fadeSpeed = newSpeed;
         state.targetWeight = targetWeight;
     }
 

--- a/Assets/SimpleAnimationComponent/Tests/PlaymodeTests/ComparativeTests/PlaybackTests.cs
+++ b/Assets/SimpleAnimationComponent/Tests/PlaymodeTests/ComparativeTests/PlaybackTests.cs
@@ -266,6 +266,28 @@ public class PlaybackTests
 		}
 
         [UnityTest]
+        public IEnumerator Crossfade_EveryFrame_Resets_Crossfade_Duration([ValueSource(typeof(ComparativeTestFixture), "Sources")]System.Type type)
+        {
+            IAnimation animation = ComparativeTestFixture.Instantiate(type);
+            var clip = Resources.Load<AnimationClip>("LinearX");
+            var clip2 = Resources.Load<AnimationClip>("LinearY");
+            var clipInstance = Object.Instantiate<AnimationClip>(clip);
+            var clipInstance2 = Object.Instantiate<AnimationClip>(clip2);
+            clipInstance.legacy = animation.usesLegacy;
+            clipInstance2.legacy = animation.usesLegacy;
+
+            animation.AddClip(clipInstance, "ToPlay");
+            animation.AddClip(clipInstance2, "ToCrossfade");
+            animation.Play("ToPlay");
+            animation.CrossFade("ToCrossfade", 0.2f);
+            yield return new WaitForSeconds(0.1f);
+            animation.CrossFade("ToCrossfade", 0.2f);
+
+            Assert.IsTrue(animation.IsPlaying("ToPlay"));
+            Assert.Less(animation.GetState("ToCrossfade").weight, 1.0f);
+        }
+
+        [UnityTest]
         [Ignore("Wrong Assumption; clips don't get kept alive by crossfade")]
         public IEnumerator Crossfade_FromFinishingClip_KeepsClipAlive_UntilCrossfadeDone([ValueSource(typeof(ComparativeTestFixture), "Sources")]System.Type type)
         {

--- a/Assets/SimpleAnimationComponent/Tests/PlaymodeTests/ComparativeTests/PlaybackTests.cs
+++ b/Assets/SimpleAnimationComponent/Tests/PlaymodeTests/ComparativeTests/PlaybackTests.cs
@@ -266,7 +266,7 @@ public class PlaybackTests
 		}
 
         [UnityTest]
-        public IEnumerator Crossfade_EveryFrame_Resets_Crossfade_Duration([ValueSource(typeof(ComparativeTestFixture), "Sources")]System.Type type)
+        public IEnumerator Crossfade_MultipleTimes_DoesntReset_Crossfade_Duration([ValueSource(typeof(ComparativeTestFixture), "Sources")]System.Type type)
         {
             IAnimation animation = ComparativeTestFixture.Instantiate(type);
             var clip = Resources.Load<AnimationClip>("LinearX");
@@ -282,9 +282,9 @@ public class PlaybackTests
             animation.CrossFade("ToCrossfade", 0.2f);
             yield return new WaitForSeconds(0.1f);
             animation.CrossFade("ToCrossfade", 0.2f);
-
-            Assert.IsTrue(animation.IsPlaying("ToPlay"));
-            Assert.Less(animation.GetState("ToCrossfade").weight, 1.0f);
+            yield return new WaitForSeconds(0.11f);
+            Assert.AreEqual(0.0f, animation.GetState("ToPlay").weight);
+            Assert.AreEqual(1.0f, animation.GetState("ToCrossfade").weight);
         }
 
         [UnityTest]


### PR DESCRIPTION
Aligned SimpleAnimation Crossfade with Legacy Animation Crossfade: 

If Crossfading a state to a new Weight slower than an existing Crossfade transition, ignore new Crossfade and keep previous speed