### PR TITLE
[Issue #24] Fix for crossfaded out clips not being stopped

### DIFF
--- a/Assets/SimpleAnimationComponent/Tests/PlaymodeTests/ComparativeTests/BaseConditionsTests.cs
+++ b/Assets/SimpleAnimationComponent/Tests/PlaymodeTests/ComparativeTests/BaseConditionsTests.cs
@@ -42,7 +42,6 @@ public class BaseConditionsTests
         animation.gameObject.GetComponent<MeshRenderer>().enabled = false;
         animation.Play("test");
         
-
         yield return null;
         yield return null;
         Assert.AreNotEqual(Vector3.zero, animation.gameObject.transform.localPosition);

--- a/Assets/SimpleAnimationComponent/Tests/PlaymodeTests/ComparativeTests/PlaybackTests.cs
+++ b/Assets/SimpleAnimationComponent/Tests/PlaymodeTests/ComparativeTests/PlaybackTests.cs
@@ -284,6 +284,24 @@ public class PlaybackTests
         }
 
         [UnityTest]
+        public IEnumerator CrossfadedOut_Clips_AreTimeReset([ValueSource(typeof(ComparativeTestFixture), "Sources")]System.Type type)
+        {
+            IAnimation animation = ComparativeTestFixture.Instantiate(type);
+            var clip = Resources.Load<AnimationClip>("LinearX");
+            var clipInstance = Object.Instantiate<AnimationClip>(clip);
+            clipInstance.legacy = animation.usesLegacy;
+
+            animation.AddClip(clipInstance, "ToPlay");
+            animation.AddClip(clipInstance, "ToCrossfade");
+            animation.Play("ToPlay");
+            animation.CrossFade("ToCrossfade", 0.1f);
+
+            yield return new WaitForSeconds(0.2f);
+
+            Assert.AreEqual(0.0f, animation.GetState("ToPlay").normalizedTime);
+        }
+
+        [UnityTest]
         public IEnumerator Crossfade_MultipleTimes_DoesntReset_Crossfade_Duration([ValueSource(typeof(ComparativeTestFixture), "Sources")]System.Type type)
         {
             IAnimation animation = ComparativeTestFixture.Instantiate(type);


### PR DESCRIPTION
Long due refactor of StateInfo to fix hard-to-debug state management and fix issue with Faded out clips not stopping.