### PR TITLE
Fix for issue #46: Disabled both IK options on clip playables

### DIFF
--- a/Assets/SimpleAnimationComponent/SimpleAnimationPlayable.cs
+++ b/Assets/SimpleAnimationComponent/SimpleAnimationPlayable.cs
@@ -109,6 +109,8 @@ public partial class SimpleAnimationPlayable : PlayableBehaviour
         }
 
         var clipPlayable = AnimationClipPlayable.Create(graph, clip);
+        clipPlayable.SetApplyFootIK(false);
+        clipPlayable.SetApplyPlayableIK(false);
         if (!clip.isLooping || newState.wrapMode == WrapMode.Once)
         {
             clipPlayable.SetDuration(clip.length);


### PR DESCRIPTION
Foot IK is enabled by default in clip playables.
Since foot IK is not part of the Animation's component API, we disable it by default